### PR TITLE
Add scala support

### DIFF
--- a/packages/client/src/const.ts
+++ b/packages/client/src/const.ts
@@ -210,6 +210,7 @@ export const SUPPORTED_CODING_LANGAUGES = [
   { value: 'ruby', aliases: ['rb'], name: 'Ruby', codeMirrorMap: 'ruby' },
   { value: 'rust', aliases: [], name: 'Rust', codeMirrorMap: 'rust' },
   { value: 'sass', aliases: [], name: 'Sass', codeMirrorMap: 'sass' },
+  { value: 'scala', aliases: [], name: 'Scala', codeMirrorMap: 'scala' },
   { value: 'sql', aliases: [], name: 'SQL', codeMirrorMap: 'sql' },
   { value: 'stylus', aliases: [], name: 'Stylus', codeMirrorMap: 'stylus' },
   { value: 'swift', aliases: [], name: 'Swift', codeMirrorMap: 'swift' },


### PR DESCRIPTION
Hi, I've noticed Scala is not supported by Wave Snippets but it's only a question of configuration because CodeMirror does support it. I've added it. 

Thanks!